### PR TITLE
feat(ui): add personal best components

### DIFF
--- a/src/components/__tests__/personal-best-card.test.tsx
+++ b/src/components/__tests__/personal-best-card.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { PersonalBestCard } from '../personal-best-card'
+import type { PersonalBestRecord } from '@/lib/personal-bests-types'
+
+describe('PersonalBestCard', () => {
+  const mockRecord: PersonalBestRecord = {
+    id: '1',
+    trackId: 123,
+    trackName: 'Nurburgring',
+    configName: 'GP',
+    carId: 456,
+    carName: 'Ferrari 296 GT3',
+    fastestLap: '1:55.000',
+    fastestLapMs: 115000,
+    seriesName: 'GT3 Challenge',
+    category: 'Sports Car',
+    subsessionId: '789',
+    raceDate: '2024-01-01T00:00:00Z',
+    year: 2024,
+    season: 'Season 1',
+    strengthOfField: 2500,
+    finishPosition: 1,
+    totalRaceIncidents: 0,
+  }
+
+  test('renders personal best information', () => {
+    render(<PersonalBestCard record={mockRecord} />)
+    expect(screen.getByText('Nurburgring (GP)')).toBeDefined()
+    expect(screen.getByText('Ferrari 296 GT3')).toBeDefined()
+    expect(screen.getByText('1:55.000')).toBeDefined()
+  })
+
+  test('calls onSelect when clicked', () => {
+    const onSelect = jest.fn()
+    render(<PersonalBestCard record={mockRecord} onSelect={onSelect} />)
+    fireEvent.click(screen.getByText('1:55.000'))
+    expect(onSelect).toHaveBeenCalledWith(mockRecord)
+  })
+})

--- a/src/components/__tests__/personal-bests-detail-modal.test.tsx
+++ b/src/components/__tests__/personal-bests-detail-modal.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import { PersonalBestsDetailModal } from '../personal-bests-detail-modal'
+import type { PersonalBestRecord } from '@/lib/personal-bests-types'
+
+describe('PersonalBestsDetailModal', () => {
+  const mockRecord: PersonalBestRecord = {
+    id: '1',
+    trackId: 123,
+    trackName: 'Nurburgring',
+    configName: 'GP',
+    carId: 456,
+    carName: 'Ferrari 296 GT3',
+    fastestLap: '1:55.000',
+    fastestLapMs: 115000,
+    seriesName: 'GT3 Challenge',
+    category: 'Sports Car',
+    subsessionId: '789',
+    raceDate: '2024-01-01T00:00:00Z',
+    year: 2024,
+    season: 'Season 1',
+    strengthOfField: 2500,
+    finishPosition: 1,
+    totalRaceIncidents: 0,
+  }
+
+  test('renders details when open', () => {
+    render(
+      <PersonalBestsDetailModal
+        record={mockRecord}
+        open={true}
+        onOpenChange={() => {}}
+      />
+    )
+
+    expect(screen.getByText('Nurburgring')).toBeDefined()
+    expect(screen.getByText('Ferrari 296 GT3')).toBeDefined()
+    expect(screen.getByText('1:55.000')).toBeDefined()
+    expect(screen.getByText('Strength of Field')).toBeDefined()
+  })
+})

--- a/src/components/__tests__/personal-bests-series-section.test.tsx
+++ b/src/components/__tests__/personal-bests-series-section.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { PersonalBestsSeriesSection } from '../personal-bests-series-section'
+import type { SeriesPersonalBests, PersonalBestRecord } from '@/lib/personal-bests-types'
+
+describe('PersonalBestsSeriesSection', () => {
+  const mockRecord: PersonalBestRecord = {
+    id: '1',
+    trackId: 123,
+    trackName: 'Nurburgring',
+    configName: 'GP',
+    carId: 456,
+    carName: 'Ferrari 296 GT3',
+    fastestLap: '1:55.000',
+    fastestLapMs: 115000,
+    seriesName: 'GT3 Challenge',
+    category: 'Sports Car',
+    subsessionId: '789',
+    raceDate: '2024-01-01T00:00:00Z',
+    year: 2024,
+    season: 'Season 1',
+    strengthOfField: 2500,
+    finishPosition: 1,
+    totalRaceIncidents: 0,
+  }
+
+  const mockSeries: SeriesPersonalBests = {
+    seriesName: 'GT3 Challenge',
+    category: 'Sports Car',
+    trackLayoutBests: {
+      '123_GP': {
+        trackLayoutKey: '123_GP',
+        trackName: 'Nurburgring',
+        configName: 'GP',
+        trackId: 123,
+        category: 'Sports Car',
+        carBests: {
+          'Ferrari 296 GT3': mockRecord,
+        },
+        totalRaces: 1,
+        fastestOverall: '1:55.000',
+        fastestOverallMs: 115000,
+        mostRecentRace: '2024-01-01T00:00:00Z',
+      },
+    },
+    totalRaces: 1,
+    uniqueTrackLayouts: 1,
+    uniqueCars: 1,
+    averageSoF: 2500,
+    bestOverallLap: '1:55.000',
+    bestOverallLapMs: 115000,
+  }
+
+  test('renders series section with cards and opens modal', () => {
+    render(<PersonalBestsSeriesSection series={mockSeries} />)
+    expect(screen.getByText('GT3 Challenge')).toBeDefined()
+    expect(screen.getByText('Nurburgring (GP)')).toBeDefined()
+
+    fireEvent.click(screen.getByText('1:55.000'))
+    expect(screen.getByText('Strength of Field')).toBeDefined()
+  })
+})

--- a/src/components/personal-best-card.tsx
+++ b/src/components/personal-best-card.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import type { PersonalBestRecord } from '@/lib/personal-bests-types'
+
+interface PersonalBestCardProps {
+  record: PersonalBestRecord
+  onSelect?: (record: PersonalBestRecord) => void
+}
+
+export function PersonalBestCard({ record, onSelect }: PersonalBestCardProps) {
+  return (
+    <Card className='cursor-pointer hover:bg-muted/50' onClick={() => onSelect?.(record)}>
+      <CardHeader className='pb-2'>
+        <CardTitle className='text-sm font-medium truncate'>
+          {record.trackName}
+          {record.configName ? ` (${record.configName})` : ''}
+        </CardTitle>
+        <CardDescription className='text-xs text-muted-foreground truncate'>
+          {record.carName}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className='text-2xl font-bold'>{record.fastestLap}</div>
+        {record.iratingAnalysis && (
+          <p className='text-xs text-muted-foreground'>
+            iR eq: {record.iratingAnalysis.iratingEquivalency.estimatedIRating}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/personal-bests-detail-modal.tsx
+++ b/src/components/personal-bests-detail-modal.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog'
+import type { PersonalBestRecord } from '@/lib/personal-bests-types'
+
+interface PersonalBestsDetailModalProps {
+  record: PersonalBestRecord | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function PersonalBestsDetailModal({ record, open, onOpenChange }: PersonalBestsDetailModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        {record && (
+          <>
+            <DialogHeader>
+              <DialogTitle>{record.trackName}</DialogTitle>
+              <DialogDescription>{record.carName}</DialogDescription>
+            </DialogHeader>
+            <div className='space-y-2 text-sm'>
+              <div className='flex justify-between'>
+                <span className='text-muted-foreground'>Fastest Lap</span>
+                <span className='font-medium'>{record.fastestLap}</span>
+              </div>
+              <div className='flex justify-between'>
+                <span className='text-muted-foreground'>Series</span>
+                <span className='font-medium'>{record.seriesName}</span>
+              </div>
+              <div className='flex justify-between'>
+                <span className='text-muted-foreground'>Strength of Field</span>
+                <span className='font-medium'>{record.strengthOfField}</span>
+              </div>
+              <div className='flex justify-between'>
+                <span className='text-muted-foreground'>Finish Position</span>
+                <span className='font-medium'>{record.finishPosition}</span>
+              </div>
+              <div className='flex justify-between'>
+                <span className='text-muted-foreground'>Race Date</span>
+                <span className='font-medium'>{new Date(record.raceDate).toLocaleDateString()}</span>
+              </div>
+              {record.iratingAnalysis && (
+                <div className='flex justify-between'>
+                  <span className='text-muted-foreground'>iR Est.</span>
+                  <span className='font-medium'>
+                    {record.iratingAnalysis.iratingEquivalency.estimatedIRating}
+                  </span>
+                </div>
+              )}
+              {record.weatherConditions?.temperature && (
+                <div className='flex justify-between'>
+                  <span className='text-muted-foreground'>Track Temp</span>
+                  <span className='font-medium'>{record.weatherConditions.temperature}°C</span>
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/personal-bests-series-section.tsx
+++ b/src/components/personal-bests-series-section.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useState } from 'react'
+import type { SeriesPersonalBests, PersonalBestRecord } from '@/lib/personal-bests-types'
+import { PersonalBestCard } from './personal-best-card'
+import { PersonalBestsDetailModal } from './personal-bests-detail-modal'
+
+interface PersonalBestsSeriesSectionProps {
+  series: SeriesPersonalBests
+}
+
+export function PersonalBestsSeriesSection({ series }: PersonalBestsSeriesSectionProps) {
+  const [selected, setSelected] = useState<PersonalBestRecord | null>(null)
+
+  const records = Object.values(series.trackLayoutBests).flatMap((layout) =>
+    Object.values(layout.carBests)
+  )
+
+  return (
+    <section className='space-y-4'>
+      <h2 className='text-xl font-semibold'>{series.seriesName}</h2>
+      <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+        {records.map((record) => (
+          <PersonalBestCard
+            key={record.id}
+            record={record}
+            onSelect={(r) => setSelected(r)}
+          />
+        ))}
+      </div>
+      <PersonalBestsDetailModal
+        record={selected}
+        open={!!selected}
+        onOpenChange={(open) => {
+          if (!open) setSelected(null)
+        }}
+      />
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- add PersonalBestCard for track/car lap display
- add PersonalBestsSeriesSection with modal detail view
- add unit tests for personal best components

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run typecheck`
- `npm test` *(fails: iRating Analysis Module › calculateIRatingDelta › should handle zero current iRating, DriverDashboard test)*
- `npx jest src/components/__tests__/personal-best-card.test.tsx src/components/__tests__/personal-bests-detail-modal.test.tsx src/components/__tests__/personal-bests-series-section.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b5d00ce4c48321ba6212fd604dfaf3