### PR TITLE
Integrate personal bests page with caching and dashboard preview

### DIFF
--- a/src/app/data-actions.ts
+++ b/src/app/data-actions.ts
@@ -358,8 +358,8 @@ export async function getPersonalBestsData(
 ): Promise<{ data: DriverPersonalBests | null; error: string | null; fromCache?: boolean; cacheAge?: number }> {
   try {
     const cacheKey = cacheKeys.personalBests(custId);
-    const cacheInfo = cache.getCacheInfo(cacheKey);
     if (!forceRefresh) {
+      const cacheInfo = cache.getCacheInfo(cacheKey);
       const cached = cache.get<DriverPersonalBests>(cacheKey);
       if (cached) {
         return { data: cached, error: null, fromCache: true, cacheAge: cacheInfo.age };
@@ -371,6 +371,7 @@ export async function getPersonalBestsData(
       // Fallback to expired cache if available
       const expired = cache.getExpired<DriverPersonalBests>(cacheKey);
       if (expired) {
+        const cacheInfo = cache.getCacheInfo(cacheKey);
         return { data: expired, error, fromCache: true, cacheAge: cacheInfo.age };
       }
       return { data: null, error };


### PR DESCRIPTION
## Summary
- avoid unnecessary cache info lookups when refreshing personal bests

## Testing
- `npm test`
- `npm run typecheck`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6029ae8b883219b1750f2cb9f19df