### PR TITLE
Fix warnings handling in Personal Bests debug API

### DIFF
--- a/src/app/api/debug-personal-bests/route.ts
+++ b/src/app/api/debug-personal-bests/route.ts
@@ -122,7 +122,7 @@ export async function GET(request: NextRequest) {
       seriesNames: Object.keys(transformResult.personalBests.seriesBests),
       ignoredRaces: transformResult.context.ignoredRaces.length,
       errors: transformResult.errors.length,
-      warnings: transformResult.warnings.length
+      warnings: transformResult.context.warnings.length
     })
 
     // Step 4: Return comprehensive diagnostic data
@@ -151,7 +151,7 @@ export async function GET(request: NextRequest) {
           personalBests: transformResult.personalBests,
           context: transformResult.context,
           errors: transformResult.errors,
-          warnings: transformResult.warnings
+          warnings: transformResult.context.warnings
         },
         metrics: {
           racesProcessed: transformResult.personalBests.totalRaces,
@@ -170,7 +170,7 @@ export async function GET(request: NextRequest) {
       failures: {
         ignoredRaces: transformResult.context.ignoredRaces,
         errors: transformResult.errors,
-        warnings: transformResult.warnings,
+        warnings: transformResult.context.warnings,
         potentialCauses: {
           noValidLapTimes: racesAnalysis.lapTimeDistribution.withFastestLap === 0,
           noParticipants: racesAnalysis.lapTimeDistribution.withParticipants === 0,

--- a/src/lib/personal-bests-types.ts
+++ b/src/lib/personal-bests-types.ts
@@ -149,6 +149,7 @@ export const PersonalBestTransformContextSchema = z.object({
     raceId: z.string(),
     reason: z.string(), // e.g., "Invalid lap time", "Missing track data"
   })),
+  warnings: z.array(z.string()),
 })
 
 // Export TypeScript types derived from schemas
@@ -190,6 +191,5 @@ export interface PersonalBestTransformOptions {
 export interface PersonalBestTransformResult {
   personalBests: DriverPersonalBests
   context: PersonalBestTransformContext
-  warnings: string[]
   errors: string[]
 }

--- a/src/lib/personal-bests.ts
+++ b/src/lib/personal-bests.ts
@@ -641,12 +641,12 @@ export function transformRecentRacesToPersonalBests(
       transformedAt: new Date().toISOString(),
       processingTimeMs: Math.round(processingTimeMs),
       ignoredRaces,
+      warnings,
     }
-    
+
     return {
       personalBests: validated,
       context,
-      warnings,
       errors,
     }
     
@@ -678,12 +678,12 @@ export function transformRecentRacesToPersonalBests(
       transformedAt: new Date().toISOString(),
       processingTimeMs: Math.round(processingTimeMs),
       ignoredRaces,
+      warnings,
     }
-    
+
     return {
       personalBests: emptyResult,
       context,
-      warnings,
       errors,
     }
   }


### PR DESCRIPTION
## Summary
- move transformation warnings into context and adjust types
- reference context warnings in debug-personal-bests API

## Testing
- `npm test`
- `npm test src/lib/__tests__/personal-bests.test.ts`
- `npm run typecheck`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b89d9de7a88321ba76be26a8b74af5