### PR TITLE
fix: address review feedback for race events log tab

### DIFF
--- a/src/app/race/[raceId]/page.tsx
+++ b/src/app/race/[raceId]/page.tsx
@@ -14,7 +14,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useProgressiveRaceLoading } from '@/hooks/use-progressive-race-loading';
 import { getOverallFastestLap } from '@/lib/iracing-data-transform';
-import RaceEventsLog from '@/components/race-events-log';
+import { RaceEventsLog } from '@/components/race-events-log';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ErrorBoundary } from '@/components/error-boundary';
 
@@ -70,7 +70,7 @@ export default function RaceDetailsPage() {
     return getOverallFastestLap(race.participants);
   }, [race?.participants]);
 
-  const simsessionNumber = (race as any)?.simsessionNumber ?? 0;
+  const simsessionNumber = race?.simsessionNumber ?? 0;
   const subsessionIdNumber = React.useMemo(() => parseInt(subsessionId, 10), [subsessionId]);
 
   const handleBack = () => {

--- a/src/lib/iracing-types.ts
+++ b/src/lib/iracing-types.ts
@@ -457,6 +457,7 @@ export type RaceCategory = 'Formula Car' | 'Sports Car' | 'Prototype' | 'Oval' |
 
 export interface RecentRace {
   id: string;
+  simsessionNumber?: number;
   trackName: string;
   date: string;
   year: number;


### PR DESCRIPTION
## Summary
- import `RaceEventsLog` as a named export
- access `simsessionNumber` with proper typing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b89dde62f883218c706f1dc2aaeec1